### PR TITLE
Definition of semilattice

### DIFF
--- a/semilattice.als
+++ b/semilattice.als
@@ -1,0 +1,8 @@
+open operator_tax
+
+pred semilattice(s: univ, f: s->s->s) {
+	semigroup[s,f]
+
+	idempotent[s,f]
+	commutative[s,f]
+}


### PR DESCRIPTION
Defined a semilattice.  I used the `semigroup` predicate instead of using `binop` and `associativity` separately.  I think doing so makes a nice point which I haven't seen emphasised inintroductory texts.